### PR TITLE
Correcting Tag usage in Github Action

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,6 +1,5 @@
 on:
   push:
-    branches: [ "main" ]
     # Sequence of patterns matched against refs/tags
     tags:
     - '[0-9]+.[0-9]+.[0-9]+' # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -18,10 +17,11 @@ jobs:
         run: |
           ROOT_DIR=$(pwd)
           mkdir -p ${ROOT_DIR}/build
-          mkdir -p ${ROOT_DIR}/build/factorio-event-logger_${{ github.ref }}
-          cp ${ROOT_DIR}/*.lua ${ROOT_DIR}/*.json ${ROOT_DIR}/build/factorio-event-logger_${{ github.ref }}/.
+          mkdir -p ${ROOT_DIR}/build/event-logger_${{ github.ref_name }}
+          cp ${ROOT_DIR}/*.lua ${ROOT_DIR}/*.json ${ROOT_DIR}/build/event-logger_${{ github.ref_name }}/.
           cd ${ROOT_DIR}/build || exit 1
-          zip ${ROOT_DIR}/build/factorio-event-logger_${{ github.ref }}.zip factorio-event-logger_${{ github.ref }}
+          sed -i "s/@@VERSION@@/${{ github.ref_name }}/g" event-logger_${{ github.ref_name }}/info.json
+          zip ${ROOT_DIR}/build/event-logger_${{ github.ref_name }}.zip event-logger_${{ github.ref_name }}
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: Release ${{ github.ref_name }}
           body : ${{ github.event.head_commit.message }}
           draft: false
           prerelease: false
@@ -40,6 +40,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./build/factorio-event-logger_${{ github.ref }}.zip
+          asset_path: ./build/event-logger_${{ github.ref_name }}.zip
           asset_name: my-artifact.zip
           asset_content_type: application/zip

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "events-logger",
-  "version": "0.0.1",
+  "version": "@@VERSION@@",
   "title": "Events Logger",
   "author": "James Boylan",
   "factorio_version": "2.0",


### PR DESCRIPTION
* `github.ref` returns the full path for the tag. Changed to `github.ref_name` to only use the actual version tag.
* Renamed from `factorio-event-logger-mod` to just `events-logger` to allow publishing to Factorio.