### PR TITLE
Upgrade Factorio support and fork from original

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - '[0-9]+.[0-9]+.[0-9]+' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+name: Upload Release Asset
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Build project # This would actually build your project, using zip for an example artifact
+        run: |
+          ROOT_DIR=$(pwd)
+          mkdir -p ${ROOT_DIR}/build
+          mkdir -p ${ROOT_DIR}/build/event-logger_${{ github.ref_name }}
+          cp ${ROOT_DIR}/*.lua ${ROOT_DIR}/*.json ${ROOT_DIR}/build/event-logger_${{ github.ref_name }}/.
+          cd ${ROOT_DIR}/build || exit 1
+          sed -i "s/@@VERSION@@/${{ github.ref_name }}/g" event-logger_${{ github.ref_name }}/info.json
+          zip ${ROOT_DIR}/build/event-logger_${{ github.ref_name }}.zip event-logger_${{ github.ref_name }}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref_name }}
+          body : ${{ github.event.head_commit.message }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./build/event-logger_${{ github.ref_name }}.zip
+          asset_name: event-logger_${{ github.ref_name }}.zip
+          asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/.idea/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+
+# Factorio ignores
+factorio.env.local
+build/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,75 @@
-# Factorio-Event-Logger-Mod
-A mod created to extend the basic logging of Factorio
+# Factorio Event Logger
 
-Can be used together with https://github.com/royvandongen/facbridge
+This mod is a fork of [royvandongen
+Factorio-Event-Logger-Mod](https://github.com/royvandongen/Factorio-Event-Logger-Mod) which does not appear to be 
+getting updated. 
+
+It provides an event logging system for Factorio that generates formatted event logs based on events documented in the  
+[Events API](https://lua-api.factorio.com/latest/events.html), enabling server administrators and players to track 
+game events.
+
+## Features
+
+- **Player Deaths**  
+  Logs the death of a player, identifying the cause (PvP, environmental, etc.).
+
+- **Player Join/Leave**  
+  Tracks when players join or leave the game and logs their leave reason (e.g., quit, kicked, desync).
+
+- **Chat Logging**  
+  Records all chat messages with the sender's name.
+
+- **Research Events**  
+  Logs the start, completion, and cancellation of research projects.
+
+- **Entity Placement Tracking**  
+  Tracks and logs the number of entities placed by each player.
+
+- **Rocket Launches**  
+  Logs whenever a rocket is launched.
+
+- **Evolution Factor Monitoring**  
+  Periodically logs the enemy evolution factor.
+
+- **Artillery Events**  
+  Tracks and logs artillery triggers.
+
+- **Playtime and Statistics**  
+  Periodically logs playtime and entity placement statistics for each player.
+
+## Installation
+
+### Mod Portal Installation
+1. Search for "Events Logger" in the in-game Mod Portal.
+2. Click the "Install" button to add the mod to your game.
+
+### Manual Installation
+1. Download or clone this repository.
+2. Place the mod folder into your Factorio `mods` directory.
+3. Start Factorio, and enable the mod in the Mod Manager.
+
+## Current Hooks
+
+This mod uses the following event hooks:
+
+- `on_rocket_launched`
+- `on_research_started`
+- `on_research_finished`
+- `on_research_cancelled`
+- `on_player_joined_game`
+- `on_player_left_game`
+- `on_pre_player_died`
+- `on_built_entity`
+- `on_trigger_fired_artillery`
+- `on_console_chat`
+
+The statistics logging is performed every 10 minutes.
+
+## Usage
+
+All logs are saved in the standard log output. You can review these logs for detailed insights into player 
+activities, game events, and overall server health.
+
+## License
+
+This mod is released under the MIT License. Feel free to modify and distribute as needed.

--- a/build-artifact
+++ b/build-artifact
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+echo "Evaluating Version Information"
+R_MASTER_VERSION=$1
+echo "Latest Tag: $R_MASTER_VERSION"
+MASTER_VERSION=${R_MASTER_VERSION:-0.0.1}
+echo "Master Version: $MASTER_VERSION"
+TAGGED_VERSION=$(git tag --points-at HEAD)
+echo "Tagged Version: $TAGGED_VERSION"
+BUILD_VERSION=${TAGGED_VERSION:-$MASTER_VERSION}
+ROOT_DIR=$(pwd)
+
+echo "Build Version: $BUILD_VERSION"
+
+if [ -f ${ROOT_DIR}/build/packaging.log ]; then
+    rm ${ROOT_DIR}/build/packaging.log
+fi
+mkdir -p ${ROOT_DIR}/build
+if [[ ! -f ${ROOT_DIR}/build/factorio-event-logger_${BUILD_VERSION}.zip ]]; then
+    mkdir -p ${ROOT_DIR}/build/factorio-event-logger_${BUILD_VERSION}
+    cp ${ROOT_DIR}/*.lua ${ROOT_DIR}/*.json ${ROOT_DIR}/build/factorio-event-logger_${BUILD_VERSION}/.
+    cd ${ROOT_DIR}/build || exit 1
+    echo "Creating Build Artifact"
+    7z a ${ROOT_DIR}/build/factorio-event-logger_${BUILD_VERSION}.zip factorio-event-logger_${BUILD_VERSION} 2>&1 > ${ROOT_DIR}/build/packaging.log
+    RC=$?
+    cd ${ROOT_DIR} || exit 1
+    if [[ $RC -ne 0 ]]; then
+        echo "Failed to Create Build Artifact"
+        cat ${ROOT_DIR}/build/packaging.log
+        exit $RC
+    else
+        echo "Build Artifact Created"
+        rm -rf ${ROOT_DIR}/build/factorio-event-logger_${BUILD_VERSION}
+        exit 0
+    fi
+else
+    echo "Build Artifact Already Exists"
+    exit 2
+fi

--- a/info.json
+++ b/info.json
@@ -1,9 +1,9 @@
 {
-  "name": "Factorio-Event-Logger",
-  "version": "0.10.0",
-  "title": "Factorio Event Logger",
-  "author": "rvandongen",
-  "factorio_version": "1.1",
-  "homepage": "https://github.com/royvandongen/Factorio-Event-Logger-Mod",
-  "dependencies": ["base"]
+  "name": "events-logger",
+  "version": "@@VERSION@@",
+  "title": "Events Logger",
+  "author": "James Boylan",
+  "factorio_version": "2.0",
+  "homepage": "https://github.com/Ralnoc/factorio-events-logger",
+  "dependencies": ["base", "space-age"]
 }

--- a/logger.lua
+++ b/logger.lua
@@ -8,7 +8,6 @@ local function on_pre_player_died (e)
 	end
 end
 
--- Determines and logs a leave reason for a player leaving, logs it to script-output/ext/awflogging.out
 local function on_player_left_game(e)
 	local player = game.get_player(e.player_index)
 	local reason
@@ -75,36 +74,36 @@ end
 local function on_built_entity(event)
 	-- get the corresponding data
 	local player = game.get_player(event.player_index)
-	local data = global.playerstats[player.name]
+	local data = storage.playerstats[player.name]
 	if data == nil then
 		-- format of array: {entities placed, ticks played}
-		global.playerstats[player.name] = {1, 0}
+		storage.playerstats[player.name] = {1, 0}
 	else
 		data[1] = data[1] + 1 --indexes start with 1 in lua
-		global.playerstats[player.name] = data
+		storage.playerstats[player.name] = data
 	end
 end
 
 local function on_init ()
-	global.playerstats = {}
+	storage.playerstats = {}
 end
 
 local function logStats()
 	-- log built entities and playtime of players
 	for _, p in pairs(game.players)
 	do
-		local pdat = global.playerstats[p.name]
+		local pdat = storage.playerstats[p.name]
 		if (pdat == nil) then
 				-- format of array: {entities placed, ticks played}
 				pdat = {0, p.online_time}
 				log("[STATS] " .. p.name .. " " .. 0 .. " " .. p.online_time)
-				global.playerstats[p.name] = pdat
+				storage.playerstats[p.name] = pdat
 		else
 			if (pdat[1] ~= 0 or (p.online_time - pdat[2]) ~= 0) then
 				log("[STATS] " .. p.name .. " " .. pdat[1] .. " " .. (p.online_time - pdat[2]))
 			end
 			-- update the data
-			global.playerstats[p.name] = {0, p.online_time}
+			storage.playerstats[p.name] = {0, p.online_time}
 		end
 	end
 end
@@ -134,10 +133,10 @@ logging.events = {
 }
 
 logging.on_nth_tick = {
-	[60*60*60] = function() -- every 60 minutes
+	[60*60*10] = function() -- every 10 minutes
 		logStats()
 	end,
-	[60*60*60] = checkEvolution,
+	[60*60*10] = checkEvolution,
 }
 
 logging.on_init = on_init

--- a/scripts/backup-factorio.sh
+++ b/scripts/backup-factorio.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd /opt/factorio
+mkdir -p backups
+tar -czvf backups/darkmatter-gaming-factorio-backup-$(date +"%Y%m%d%H%M%S").tar.gz data

--- a/scripts/init-env.sh
+++ b/scripts/init-env.sh
@@ -1,0 +1,287 @@
+ENVIRONMENT_CONFIG=${FACTORIO_PATH}/config/factorio.env
+PATH=$PATH:${FACTORIO_PATH}/bin
+
+function debug() {
+  if [ "${DEBUG-0}" -gt 0 ]; then
+    echo "DEBUG: $*"
+  fi
+}
+
+function error() {
+  echo "$*" 1>&2
+}
+
+function info() {
+  echo "$*"
+}
+
+function load_config() {
+  # unless a path is provided as the first argument,
+  # assume there's a "config" file in our current directory.
+  config_file="${ENVIRONMENT_CONFIG}"; shift
+  debug "Trying to load config file '${config_file}'."
+
+  # check that the file exists
+  [ -f "${config_file}" ] || { error "Config file '${config_file}' does not exist!"; return 1; }
+  # and we can read it
+  [ -r "${config_file}" ] || { error "Unable to read config file '${config_file}'!"; return 1; }
+  # then try to source it
+  # shellcheck disable=SC1090
+  source "${config_file}" || { error "Unable to source config file '${config_file}'!"; return 1; }
+
+  config_defaults
+  return $?
+}
+
+function config_defaults() {
+  debug "Check/Loading config defaults for command '${command}'"
+
+  ME=$(whoami)
+
+  if [ -z "${SERVICE_NAME}" ]; then
+    SERVICE_NAME="Factorio"
+  fi
+
+  if [ -z "${USERGROUP}" ]; then
+    USERGROUP=${USERNAME}
+  fi
+
+  if [ -z "${HEADLESS}" ]; then
+    HEADLESS=1
+  fi
+
+  if [ -z "${UPDATE_EXPERIMENTAL}" ]; then
+    UPDATE_EXPERIMENTAL=0
+  fi
+
+  if [ -z "${LATEST_HEADLESS_URL}" ]; then
+    if [ "${UPDATE_EXPERIMENTAL}" -gt 0 ]; then
+      LATEST_HEADLESS_URL="https://www.factorio.com/get-download/latest/headless/linux64"
+    else
+      LATEST_HEADLESS_URL="https://www.factorio.com/get-download/stable/headless/linux64"
+    fi
+  fi
+
+  if [ -z "${UPDATE_PREVENT_RESTART}" ]; then
+    UPDATE_PREVENT_RESTART=0
+  fi
+
+  if [ -z "${UPDATE_PERSIST_TMPDIR}" ]; then
+    UPDATE_PERSIST_TMPDIR=0
+  fi
+
+  if [ -z "${NONCMDPATTERN}" ]; then
+    NONCMDPATTERN='(^\s*(\s*[0-9]+\.[0-9]+|\)|\())|(Players:$)'
+  fi
+
+  if [ -z "${FACTORIO_PATH}" ]; then
+    FACTORIO_PATH="/opt/factorio"
+  fi
+
+  if [ -z "${BINARY}" ]; then
+    BINARY="${FACTORIO_PATH}/bin/x64/factorio"
+  fi
+
+  if [ -z "${BINARYB}" ]; then
+    BINARYB="${BINARY}"
+  fi
+
+  if [ -z "${ALT_GLIBC}" ]; then
+    ALT_GLIBC=0
+  fi
+
+  if [ -z "${WAIT_PINGPONG}" ]; then
+    WAIT_PINGPONG=0
+  fi
+
+  if [ -z "${FORCED_SHUTDOWN}" ]; then
+    FORCED_SHUTDOWN=15
+  fi
+
+  if [ -z "${ADMINLIST}" ]; then
+    ADMINLIST="${FACTORIO_PATH}/data/server-adminlist.json"
+  fi
+
+  if [ "${ALT_GLIBC}" -gt 0 ]; then
+    if [ -z "${ALT_GLIBC_DIR}" ]; then
+      ALT_GLIBC_DIR="/opt/glibc-2.18"
+    fi
+
+    if [ -z "${ALT_GLIBC_VER}" ]; then
+      ALT_GLIBC_VER="2.18"
+    fi
+
+    # flip BINARY to include alt glibc
+    oldbinary="${BINARY}"
+    BINARY="${ALT_GLIBC_DIR}/lib/ld-${ALT_GLIBC_VER}.so --library-path ${ALT_GLIBC_DIR}/lib ${oldbinary}"
+    echo ${BINARY}
+    EXE_ARGS_GLIBC="--executable-path ${BINARYB}"
+  fi
+
+  if [ -z "${FCONF}" ]; then
+    FCONF="${FACTORIO_PATH}/config/config.ini"
+  fi
+
+  if [ -z "${SERVER_SETTINGS}" ]; then
+    SERVER_SETTINGS="${FACTORIO_PATH}/data/server-settings.json"
+  fi
+
+  if [ -z "${SAVELOG}" ]; then
+    SAVELOG=0
+  fi
+
+  if [ -n "${PORT}" ]; then
+    PORT="--port ${PORT}"
+  fi
+
+  if [ -n "${ENABLE_RCON}" ]; then
+    if [ -z "${RCON_BIND_IP}" ]; then
+      RCON_BIND_IP="0.0.0.0"
+    fi
+
+    if [ -z "${RCON_BIND_PORT}" ]; then
+      RCON_BIND_PORT="27015"
+    fi
+
+    if [ -z "${RCON_PASSWORD}" ]; then
+      echo "RCON_PASSWORD is not set, please set it in ${ENVIORNMENT_CONFIG}"
+      exit 1
+    fi
+
+    RCON_ARGS="--rcon-bind ${RCON_BIND_IP}:${RCON_BIND_PORT} --rcon-password ${RCON_PASSWORD}"
+  fi
+
+  if [ -z "${INSTALL_CACHE_TAR}" ]; then
+    INSTALL_CACHE_TAR=0
+  fi
+
+  if [ -z "${INSTALL_CACHE_DIR}" ]; then
+    INSTALL_CACHE_DIR=/tmp/factorio-install.cache
+  fi
+
+  if ! [ -e "${BINARYB}" ]; then
+    error "Could not find factorio binary! ${BINARYB}"
+    error "(if you store your binary some place else, override BINARY='/your/path' in the config)"
+    return 1
+  fi
+
+  if ! [ -e "${SERVER_SETTINGS}" ]; then
+    error "Could not find factorio server settings file: ${SERVER_SETTINGS}"
+    error "Update your config and point SERVER_SETTINGS to a modified version of data/server-settings.example.json"
+    return 1
+  fi
+
+  if ! [ -e "${FCONF}" ]; then
+    echo "Could not find factorio config file: ${FCONF}"
+    echo "If this is the first time you run this script you need to generate the config.ini by starting the server manually."
+    echo "(also make sure you have a save to run or the server will not start)"
+    echo
+    echo "Create save: sudo -u ${USERNAME} ${BINARY} --create ${FACTORIO_PATH}/saves/my_savegame ${EXE_ARGS_GLIBC}"
+    echo "Start server: sudo -u ${USERNAME} ${BINARY} --start-server-load-latest ${EXE_ARGS_GLIBC}"
+    echo
+    echo "(If you rather store the config.ini in another location, set FCONF='/your/path' in this scripts config file)"
+    return 1
+  fi
+
+  if [ -z "${WRITE_DIR}" ]; then
+    # figure out the write-data path (where factorio looks for saves and mods)
+    # Note - this is a hefty little operation, possible cause of head ache down the road
+    # as it relies on the factorio write dir to live ../../ up from the binary if __PATH__executable__
+    # is used in the config file.. for now, that's the default so cross your fingers it will not change ;)
+    debug "Determining WRITE_DIR based on ${FCONF}, IF you edited write-data from the default, this probably fails"
+    WRITE_DIR=$(realpath $(dirname "$(grep "^write-data=" "$FCONF" |cut -d'=' -f2 |sed -e 's#__PATH__executable__#'"$(dirname ${BINARYB})"/..'#g')"))
+  fi
+  debug "write path: $WRITE_DIR"
+
+  if [ -z "${FIFO}" ];then
+    FIFO="${WRITE_DIR}/server.fifo"
+  fi
+
+  if [ -z "${CMDOUT}" ];then
+    CMDOUT="${WRITE_DIR}/server.out"
+  fi
+
+  # Finally, set up the invocation
+  INVOCATION="${BINARY} --config ${FCONF} ${PORT} --start-server-load-latest --server-settings ${SERVER_SETTINGS} --server-adminlist ${ADMINLIST} ${RCON_ARGS}"
+  if [ -n "${WHITELIST}" ] && [ -e "${WHITELIST}" ]; then
+    INVOCATION+=" --server-whitelist ${WHITELIST} --use-server-whitelist"
+  fi
+  if [ -n "${BANLIST}" ] && [ -e "${BANLIST}" ]; then
+    INVOCATION+=" --server-banlist ${BANLIST}"
+  fi
+  INVOCATION+=" ${EXTRA_BINARGS}"
+
+  return 0
+}
+
+
+function send_cmd(){
+  NEED_OUTPUT=0
+  if [ "$1" == "-o" ]; then
+    NEED_OUTPUT=1
+    shift
+  fi
+  if is_running; then
+    if [ -p "${FIFO}" ]; then
+      # Generate two unique log markers
+      TIMESTAMP=$(date +"%s")
+      START="FACTORIO_INIT_CMD_${TIMESTAMP}_START"
+      END="FACTORIO_INIT_CMD_${TIMESTAMP}_END"
+
+      # Whisper that unknown player to place start marker in log
+      echo "/w $START" > "${FIFO}"
+      # Run the actual command
+      echo "$*" > "${FIFO}"
+      # Whisper that unknown player again to place end marker in log after the command terminated
+      echo "/w $END" > "${FIFO}"
+
+      if [ ${NEED_OUTPUT} -eq 1 ]; then
+        # search for the start marker in the log file, then follow and print the log output in real time until the end marker is found
+        sleep 1
+        awk "/Player $START doesn't exist./{flag=1;next}/Player $END doesn't exist./{exit}flag" < "${CMDOUT}"
+      fi
+    else
+      echo "${FIFO} is not a pipe!"
+      return 1
+    fi
+  else
+    echo "Unable to send cmd to a stopped server!"
+    return 1
+  fi
+}
+
+function usage() {
+  echo -e "\
+Usage: $0 COMMAND
+
+Available commands:
+  start \t\t\t\t\t\t Starts the server
+  stop \t\t\t\t\t\t\t Stops the server
+  restart \t\t\t\t\t\t Restarts the server
+  status \t\t\t\t\t\t Displays server status
+  players-online \t\t\t\t\t Shows online players
+  players \t\t\t\t\t\t Shows all players
+  cmd [command/message] \t\t\t\t Open interactive commandline or send a single command to the server
+  log [--tail|-t] \t\t\t\t\t Print the full server log, optionally tail the log to follow in real time
+  chatlog [--tail|-t] \t\t\t\t\t Print the current chatlog, optionally tail the log to follow in real time
+  new-game name [map-gen-settings] [map-settings] \t Stops the server and creates a new game with the specified
+  \t\t\t\t\t\t\t name using the specified map gen settings and map settings json files
+  save-game name \t\t\t\t\t Stops the server and saves game to specified save
+  load-save name \t\t\t\t\t Stops the server and loads the specified save
+  install [tarball] \t\t\t\t\t Installs the server with optional specified tarball
+  \t\t\t\t\t\t\t (omit to download and use the latest headless server from Wube)
+  update [--dry-run] \t\t\t\t\t Updates the server
+  invocation \t\t\t\t\t\t Outputs the invocation for debugging purpose
+  listcommands \t\t\t\t\t\t List all init-commands
+  listsaves \t\t\t\t\t\t List all saves
+  version \t\t\t\t\t\t Prints the binary version
+  mod \t\t\t\t\t\t\t Manage mods (see $0 mod help for more information)
+  help \t\t\t\t\t\t\t Shows this help message
+"
+}
+
+function wait_pingpong() {
+  until ping -c1 pingpong1.factorio.com &>/dev/null; do :; done
+  until ping -c1 pingpong2.factorio.com &>/dev/null; do :; done
+}
+

--- a/scripts/shutdown.sh
+++ b/scripts/shutdown.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Load the environment configuration
+PID=$1
+PATH=$PATH:/opt/factorio/bin
+source /opt/factorio/config/factorio.env
+source ${FACTORIO_PATH}/bin/init-env.sh
+load_config
+
+
+if kill -TERM "${PID}" 2> /dev/null; then
+  sec=1
+  while [ "$sec" -le "${FORCED_SHUTDOWN}" ]; do
+    if kill -0 "${PID}" 2> /dev/null; then
+      echo -n ". "
+      sleep 1
+    else
+      break
+    fi
+    sec=$((sec+1))
+  done
+fi
+
+if kill -0 "${PID}" 2> /dev/null; then
+  echo "Unable to shut down nicely, killing the process!"
+  kill -KILL "${PID}" 2> /dev/null
+else
+  echo "complete!"
+fi
+
+# Open pipe for writing.
+exec 3> "${FIFO}"
+# Write a newline to the pipe, this triggers a SIGPIPE and causes tail to exit
+echo "" >&3
+# Close pipe.
+exec 3>&-

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Load the environment configuration
+PATH=$PATH:/opt/factorio/bin
+source /opt/factorio/config/factorio.env
+source ${FACTORIO_PATH}/bin/init-env.sh
+load_config
+
+
+# ensure we have a binary to start
+if ! [ -e "${BINARYB}" ]; then
+  echo "Can't find ${BINARYB}. Please check your config!"
+  exit 1
+fi
+
+## ensure we have a fifo
+if ! [ -p "${FIFO}" ]; then
+  if ! mkfifo ${FIFO}; then
+    echo "Failed to create pipe for stdin, if applicable, remove ${FIFO} and try again"
+    exit 1
+  fi
+fi
+
+if ! [ -e ${ADMINLIST} ]; then
+  debug "${ADMINLIST} does not exist!  Creating empty file."
+  echo "[]" > ${ADMINLIST}
+  chown "${USERNAME}:${USERGROUP}" ${ADMINLIST}
+fi
+
+if [ ${WAIT_PINGPONG} -gt 0 ]; then
+  wait_pingpong
+fi
+
+tail -f ${FIFO} |${INVOCATION} ${EXE_ARGS_GLIBC}

--- a/systemd-service/factorio.env
+++ b/systemd-service/factorio.env
@@ -1,0 +1,5 @@
+FACTORIO_PATH="/opt/factorio"
+ENABLE_RCON=false # Change to true to enable RCON
+RCON_BIND_IP="0.0.0.0" # Change to your server's IP to bind RCON to a specific IP
+RCON_BIND_PORT=27015 # Change to your desired RCON port
+RCON_PASSWORD="" # Change to your desired RCON password

--- a/systemd-service/factorio.service
+++ b/systemd-service/factorio.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Factorio Dedicated Server
+Wants=network-online.target
+After=syslog.target network.target nss-lookup.target network-online.target
+
+[Service]
+ExecStart=/opt/factorio/bin/start.sh
+WorkingDirectory=/opt/factorio/
+LimitNOFILE=100000
+ExecStop=/opt/factorio/bin/shutdown.sh $MAINPID
+User=factorio
+Group=factorio
+#Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
* Fixed stats storage process to leverage `storage` instead of `global` which breaks in newest version of Factorio.
* Built out packaging process that meets the requirements of Factorio.
* Built out factorio Systemd service and supporting scripts.
* Changed default stats interval to 10 minutes instead of 60.
* Updated `README.md` and `info.json` Forked to new Event Logger mod name. Documented this is a derivative work based on https://github.com/royvandongen/Factorio-Event-Logger-Mod
* Added Github Action workflow for building and publishing a release.
* `github.ref` returns the full path for the tag. Changed to `github.ref_name` to only use the actual version tag.
* Renamed from `factorio-event-logger-mod` to just `events-logger` to allow publishing to Factorio.