### PR TITLE
Service Script updates & Logging Server Chat

### DIFF
--- a/logger.lua
+++ b/logger.lua
@@ -94,10 +94,15 @@ end
 
 local function on_console_chat(e)
 	local event_json = {}
-	local player = game.get_player(e.player_index)
-	event_json["name"] = player.name
 	event_json["event"] = "CHAT"
 	if ( e.player_index ~= nul and e.player_index ~= '' ) then
+		local player = game.get_player(e.player_index)
+		event_json["name"] = player.name
+		event_json["message"] = e.message
+		helpers.write_file("game-events.json", helpers.table_to_json(event_json) .. "\n", true)
+		log("[" .. event_json["event"] .. "] " .. event_json["name"] .. ": " .. event_json["message"])
+	else
+		event_json["name"] = "Console"
 		event_json["message"] = e.message
 		helpers.write_file("game-events.json", helpers.table_to_json(event_json) .. "\n", true)
 		log("[" .. event_json["event"] .. "] " .. event_json["name"] .. ": " .. event_json["message"])

--- a/scripts/backup-factorio.sh
+++ b/scripts/backup-factorio.sh
@@ -3,3 +3,4 @@
 cd /opt/factorio
 mkdir -p backups
 tar -czvf backups/darkmatter-gaming-factorio-backup-$(date +"%Y%m%d%H%M%S").tar.gz data
+

--- a/scripts/shutdown.sh
+++ b/scripts/shutdown.sh
@@ -7,6 +7,20 @@ source /opt/factorio/config/factorio.env
 source ${FACTORIO_PATH}/bin/init-env.sh
 load_config
 
+PLAYER_CHECK_COUNT=0
+PLAYER_CHECK_MAX=300
+while [ ${PLAYER_CHECK_COUNT} -lt ${PLAYER_CHECK_MAX} ]; do
+  PLAYERS=$(cmd_players online | wc -l)
+  if [ ${PLAYERS} -ne 0 ]; then
+    send_cmd "Server shutting down in $((${PLAYER_CHECK_MAX} / 60)) minutes!"
+    send_cmd "Please log out to avoid the risk of losing progress or being stuck in a bad location!"
+    sleep 60
+    PLAYER_CHECK_COUNT=$((${PLAYER_CHECK_COUNT}+60))
+  else
+    send_cmd "Server shutting down NOW!"
+    break
+  fi
+done
 
 if kill -TERM "${PID}" 2> /dev/null; then
   sec=1
@@ -24,13 +38,8 @@ fi
 if kill -0 "${PID}" 2> /dev/null; then
   echo "Unable to shut down nicely, killing the process!"
   kill -KILL "${PID}" 2> /dev/null
+  rm -f ${PIDFILE}
 else
   echo "complete!"
+  rm -f ${PIDFILE}
 fi
-
-# Open pipe for writing.
-exec 3> "${FIFO}"
-# Write a newline to the pipe, this triggers a SIGPIPE and causes tail to exit
-echo "" >&3
-# Close pipe.
-exec 3>&-

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -31,4 +31,5 @@ if [ ${WAIT_PINGPONG} -gt 0 ]; then
   wait_pingpong
 fi
 
-tail -f ${FIFO} |${INVOCATION} ${EXE_ARGS_GLIBC}
+tail -f ${FIFO} |${INVOCATION} 2>&1 &
+echo $! > ${PIDFILE}

--- a/systemd-service/factorio.service
+++ b/systemd-service/factorio.service
@@ -4,10 +4,12 @@ Wants=network-online.target
 After=syslog.target network.target nss-lookup.target network-online.target
 
 [Service]
+Type=forking
 ExecStart=/opt/factorio/bin/start.sh
 WorkingDirectory=/opt/factorio/
 LimitNOFILE=100000
 ExecStop=/opt/factorio/bin/shutdown.sh $MAINPID
+PIDFile=/opt/factorio/server.pid
 User=factorio
 Group=factorio
 


### PR DESCRIPTION
* Updated `on_console_chat` to log both player and server chat into the output. Messages from the server now arrive as coming from `Console`
* Fixed bug on `on_console_chat` where if it came from a source that was not a player, it would crash teh server, trying to lookup a non-existent player.
* Updated `factorio.service` so that it now leverages a PIDFile created on the start of Factorio and is a forking service. This allows for proper ownership of the service, while also outputting the PIDs to the PIDFILE and allowing console commands to be injected through the FIFO.
* Updated `cmd_players` to filter out the `Players (?):` and timestamp from the listing of users.
* Updated `send_cmd` to leverage `journalctl` for retrieving output results.
* Updated `shutdown.sh` so that it will check to see if there are players online. If there are, it will message them that the server will be shutting down in `$((${PLAYER_CHECK_MAX} / 60))` minutes. It will do this every minute, until it reaches `PLAYER_CHECK_MAX` which is set at 300 seconds (5 minutes)
* Updated `start.sh` to properly start the Factorio server, and output the PID file in a way that works with Systemd.
* Updated the contents of `README.md` to detail the JSON output for users, and correct some formatting issues.