### PR TITLE
Multiplayer ticks bug

### DIFF
--- a/logger.lua
+++ b/logger.lua
@@ -285,7 +285,9 @@ end
 local function log_tick_over_time()
 	local event_json = {}
 	event_json["event"] = "TICK"
-	event_json["ticks_player"] = game.ticks_players
+	if game.ticks_players then
+		event_json["ticks_players"] = game.ticks_players
+	end
 	event_json["current_map_Tick"] = game.tick
 	helpers.write_file("game-events.json", helpers.table_to_json(event_json) .. "\n", true)
 	log("[" .. event_json["event"] .. "] " .. event_json["tick"])


### PR DESCRIPTION
* Updated `log_tick_over_time` so that it only captures `game.ticks_players` when it exists. This fixes a bug that manifests in single player.