### PR TITLE
Resolved Tick Logging bug

### DIFF
--- a/logger.lua
+++ b/logger.lua
@@ -285,19 +285,13 @@ end
 local function log_tick_over_time()
 	local event_json = {}
 	event_json["event"] = "TICK"
-	event_json["current_map_Tick"] = game.tick
+	event_json["played_ticks"] = game.tick or "no-tick"
+	event_json["tick_paused"] = game.tick_paused or "no-tick"
+	event_json["ticks_to_run"] = game.ticks_to_run or "no-tick"
 	helpers.write_file("game-events.json", helpers.table_to_json(event_json) .. "\n", true)
-	log("[" .. event_json["event"] .. "] " .. event_json["tick"])
-end
-
-
-local function on_rocket_launched(event)
-	local event_json = {}
-	event_json["event"] = "ROCKET"
-	event_json["reason"] = "ROCKET_LAUNCHED"
-	event_json["tick"] = event.tick
-	helpers.write_file("game-events.json", helpers.table_to_json(event_json) .. "\n", true)
-	log("[" .. event_json["event"] .. "] " .. event_json["reason"])
+	log("[" .. event_json["event"] .. "] played_ticks: " .. event_json["played_ticks"])
+	log("[" .. event_json["event"] .. "] tick_paused: " .. event_json["tick_paused"])
+	log("[" .. event_json["event"] .. "] ticks_to_run: " .. event_json["ticks_to_run"])
 end
 
 
@@ -313,6 +307,16 @@ local function checkEvolution()
 		helpers.write_file("game-events.json", helpers.table_to_json(event_json) .. "\n", true)
 		log("[" .. event_json["event"] .. "] " .. string.format("Surface: %s Factor: %.4f", event_json["stats"]["surface"], event_json["stats"]["factor"]))
 	end
+end
+
+
+local function on_rocket_launched(event)
+	local event_json = {}
+	event_json["event"] = "ROCKET"
+	event_json["reason"] = "ROCKET_LAUNCHED"
+	event_json["tick"] = event.tick
+	helpers.write_file("game-events.json", helpers.table_to_json(event_json) .. "\n", true)
+	log("[" .. event_json["event"] .. "] " .. event_json["reason"])
 end
 
 

--- a/test-code.sh
+++ b/test-code.sh
@@ -17,19 +17,19 @@ LIGHTGRAY='\033[0;37m'
 WHITE='\033[1;37m'
 NC='\033[0m'
 
-printf "${LIGHTBLUE}Copying Factorio Events Logger Mod to Server at ${LIGHTCYAN}dmz-user@192.168.86.62${NC}\n"
-scp -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem ./build/events-logger_999.999.999.zip dmz-user@192.168.86.62:/home/dmz-user/. 2> /dev/null
+#printf "${LIGHTBLUE}Copying Factorio Events Logger Mod to Server at ${LIGHTCYAN}dmz-user@192.168.86.62${NC}\n"
+#scp -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem ./build/events-logger_999.999.999.zip dmz-user@192.168.86.62:/home/dmz-user/. 2> /dev/null
 printf "${LIGHTBLUE}Removing Factorio Events Logger Mod from Client at ${LIGHTCYAN}/c/Users/drahk/AppData/Roaming/Factorio/mods${NC}\n"
 rm /c/Users/drahk/AppData/Roaming/Factorio/mods/events-logger_*.zip 2> /dev/null
 printf "${LIGHTBLUE}Deploying Factorio Events Logger Mod to Client at ${LIGHTCYAN}/c/Users/drahk/AppData/Roaming/Factorio/mods${NC}\n"
 cp ./build/events-logger_999.999.999.zip /c/Users/drahk/AppData/Roaming/Factorio/mods/. 2> /dev/null
-printf "${LIGHTBLUE}Removing Factorio Events Logger Mod from ${LIGHTCYAN}/opt/factorio/mods${NC}\n"
-ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo rm /opt/factorio/mods/events-logger_*.zip" 2> /dev/null
-printf "${LIGHTBLUE}Deploying Factorio Events Logger Mod to ${LIGHTCYAN}/opt/factorio/mods${NC}\n"
-ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo mv /home/dmz-user/events-logger_999.999.999.zip /opt/factorio/mods/." 2> /dev/null
-printf "${LIGHTBLUE}Setting ownership of Factorio Events Logger Mod to ${GREEN}factorio${NC}\n"
-ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo chown factorio: /opt/factorio/mods/events-logger_999.999.999.zip" 2> /dev/null
-printf "${LIGHTBLUE}Restarting Factorio Server${NC}\n"
-ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo systemctl stop factorio ; sleep 3 ; sudo systemctl start factorio" 2> /dev/null
+#printf "${LIGHTBLUE}Removing Factorio Events Logger Mod from ${LIGHTCYAN}/opt/factorio/mods${NC}\n"
+#ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo rm /opt/factorio/mods/events-logger_*.zip" 2> /dev/null
+#printf "${LIGHTBLUE}Deploying Factorio Events Logger Mod to ${LIGHTCYAN}/opt/factorio/mods${NC}\n"
+#ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo mv /home/dmz-user/events-logger_999.999.999.zip /opt/factorio/mods/." 2> /dev/null
+#printf "${LIGHTBLUE}Setting ownership of Factorio Events Logger Mod to ${GREEN}factorio${NC}\n"
+#ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo chown factorio: /opt/factorio/mods/events-logger_999.999.999.zip" 2> /dev/null
+#printf "${LIGHTBLUE}Restarting Factorio Server${NC}\n"
+#ssh -i ~/Home\ Lab/SSH\ Keys/proxmox-vms.pem dmz-user@192.168.86.62 "sudo systemctl stop factorio ; sleep 3 ; sudo systemctl start factorio" 2> /dev/null
 rm -rf ./build
 printf "${LIGHTGREEN}Deployment Complete${NC}\n"


### PR DESCRIPTION
* Identified issue with logging ticks. They do not exist as a property during the bootstrap phase, resulting in a failure to retrieve them. Added a `no-tick` response for when those situations arise.