### PR TITLE
EL-25 Crash bug in on_achievement_gained event

### DIFF
--- a/logger.lua
+++ b/logger.lua
@@ -163,12 +163,13 @@ end
 
 local function on_achievement_gained(event)
 	local event_json = {}
-	event_json["name"] = game.get_player(event.player_index)
+	event_json["name"] = event.name
+	event_json["player"] = game.get_player(event.player_index)
 	event_json["event"] = "ACHIEVEMENT_GAINED"
 	event_json["achievement_name"] = event.achievement.name
 	event_json["tick"] = event.tick
 	write_game_event_json(event_json)
-	factorio_log(event_json["event"], event_json["name"] .. "by " .. event_json["admin"])
+	factorio_log(event_json["event"], event_json["name"] .. "by " .. event_json["player"])
 end
 
 


### PR DESCRIPTION
The issue is caused by this block of code.
```
local function on_achievement_gained(event)
	local event_json = {}
	event_json["name"] = game.get_player(event.player_index)
	event_json["event"] = "ACHIEVEMENT_GAINED"
	event_json["achievement_name"] = event.achievement.name
	event_json["tick"] = event.tick
	write_game_event_json(event_json)
	factorio_log(event_json["event"], event_json["name"] .. "by " .. event_json["admin"])
end
```

While addressing the reference to event_json["admin"], I also identified an invalid content issue for name. This block of code was updated to:

```
local function on_achievement_gained(event)
	local event_json = {}
	event_json["name"] = event.name
	event_json["player"] = game.get_player(event.player_index)
	event_json["event"] = "ACHIEVEMENT_GAINED"
	event_json["achievement_name"] = event.achievement.name
	event_json["tick"] = event.tick
	write_game_event_json(event_json)
	factorio_log(event_json["event"], event_json["name"] .. "by " .. event_json["player"])
end
```