### PR TITLE
Added support for event `on_player_changed_surface`

### DIFF
--- a/events/players.lua
+++ b/events/players.lua
@@ -125,6 +125,20 @@ function on_player_repaired_entity(event)
     factorio_log(event_json["event"], event_json["name"] .. event_json["entity"]["name"])
 end
 
+function on_player_changed_surface(event)
+    local event_json = {}
+    event_json["player_name"] = game.get_player(event.player_index).name
+    event_json["name"] = event.name
+    event_json["event"] = "CHANGED_SURFACE"
+    if event.surface_index then
+        event_json["previous_surface"] = game.get_surface(event.surface_index).name
+    end
+	event_json["player_surface"] = game.get_player(event.player_index).surface.name
+    event_json["tick"] = event.tick
+    write_game_event_json(event_json)
+    factorio_log(event_json["event"], "Player: " .. event_json["player_name"] .. " Surface: " .. event_json["player_surface"])
+end
+
 events[defines.events.on_pre_player_died] = on_pre_player_died
 events[defines.events.on_player_left_game] = on_player_left_game
 events[defines.events.on_player_joined_game] = on_player_joined_game
@@ -133,3 +147,4 @@ events[defines.events.on_player_unbanned] = on_player_unbanned
 events[defines.events.on_character_corpse_expired] = on_character_corpse_expired
 events[defines.events.on_picked_up_item] = on_picked_up_item
 events[defines.events.on_player_repaired_entity] = on_player_repaired_entity
+events[defines.events.on_player_changed_surface] = on_player_changed_surface


### PR DESCRIPTION
Hi, I've been playing around with this mod publishing the events in a message queue for a side project. I needed an event for a player changing to a different surface so I added that. I have next to no experience with LUA but I took some more time to look at the existing code this time.


The API event `on_player_changed_surface` contains the player index and the surface index of the previous surface said player was on before.
This change adds the event CHANGED_SURFACE, which contains the players name and their previous and current surface. The previous surface index may be nil, if the surface no longer exists so the previous surface is only added when available. The current surface is retrieved from the player object and is always available.

Example output JSON:
{"player_name":"player","name":55,"event":"CHANGED_SURFACE","previous_surface":"nauvis","player_surface":"platform-1","tick":29756911}

Example output factorio log:
...: [CHANGED_SURFACE] Player: player Surface: platform-1