### PR TITLE
feat: add science packs to RESEARCH_STARTED and Factorio 2.1 support

### DIFF
--- a/events/research.lua
+++ b/events/research.lua
@@ -3,11 +3,29 @@ local function get_infinite_research_name(name)
     return string.match(name, "^(.-)%-%d+$") or name
 end
 
+--- Extract the science packs consumed by a research, as tuples of
+--- {science_pack_name, amount}.
+--- science_pack_name is the internal Factorio item prototype name (e.g.
+--- "automation-science-pack"); amount is the number of that pack consumed
+--- per research unit (base game is always 1, but mods may differ).
+---@param research LuaTechnology - The technology being researched.
+---@return table - Array of tuples: {{name, amount}, ...}
+local function get_science_packs(research)
+    local packs = {}
+    for _, ingredient in ipairs(research.research_unit_ingredients or {}) do
+        local name = ingredient.name or ingredient[1]
+        local amount = ingredient.amount or ingredient[2]
+        table.insert(packs, {name, amount})
+    end
+    return packs
+end
+
 function on_research_started(event)
     local event_json = {}
     event_json["name"] = get_infinite_research_name(event.research.name)
     event_json["event"] = "RESEARCH_STARTED"
     event_json["level"] = (event.research.level or "no-level")
+    event_json["science_packs"] = get_science_packs(event.research)
     event_json["tick"] = event.tick
     write_game_event_json(event_json)
     factorio_log(event_json["event"], event_json["name"] .. " " .. event_json["level"])

--- a/info.json
+++ b/info.json
@@ -3,7 +3,7 @@
   "version": "@@VERSION@@",
   "title": "Events Logger",
   "author": "James Boylan",
-  "factorio_version": "2.0",
+  "factorio_version": "2.1",
   "homepage": "https://github.com/Ralnoc/factorio-events-logger",
   "dependencies": ["base", "space-age"]
 }


### PR DESCRIPTION
Hi there, 

I bumped the version locally to 2.1 and tested everything locally. There were no breaking changes.

Also, would you be okay with adding a bit extra to the on_research_started JSON output? I added it so that I could implement this silly project: https://github.com/sstrang/3d-synced-factorio-lab/

More generally, if someone wanted to sync a smart bulb or something to the current research, this would help them determine the correct colour.

Cheers!
